### PR TITLE
Add GitHub Action status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-https://github.com/damymetzke/Gepetto/workflows/Jest%20automatic%20test/badge.svg
+![Jest automatic test](https://github.com/damymetzke/Gepetto/workflows/Jest%20automatic%20test/badge.svg)
 
 # Gepetto
 Gepetto is a personal project.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+https://github.com/damymetzke/Gepetto/workflows/Jest%20automatic%20test/badge.svg
+
 # Gepetto
 Gepetto is a personal project.
 It's on GitHub primarily to share with peers, however it isn't licenced because it is not the intention to share this with the general public (but feel free to look through it, I don't mind).


### PR DESCRIPTION
## Changes:

- Add a cool badge with the status of the Jest tests to the top of the README file

## Context:

The basic syntax/format to add a GitHub action SVG badge is:
```
https://github.com/<OWNER>/<REPOSITORY>/workflows/<WORKFLOW_NAME>/badge.svg
```

So the pull-request uses:
```
https://github.com/damymetzke/Gepetto/workflows/Jest%20automatic%20test/badge.svg
```
I replaced the white-spaces in the GitHub action name with `%20`.

If you later change the `name` of the GitHub Action, you should also change the badge link.
https://github.com/damymetzke/Gepetto/blob/1cb2083bf107efe7525d2407a99b9d180debcb74/.github/workflows/jest.yml#L1

## References:

GitHub documentation I used to set up the badge: [Adding a workflow status badge to your repository](https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository)