### PR TITLE
Replace npm install -> npm ci

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{matrix.node-version}}
 
       - name: install
-        run: npm install
+        run: npm ci
 
       - name: lint
         run: npm run lint

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{matrix.node-version}}
 
       - name: install
-        run: npm install
+        run: npm ci
 
       - name: test
         run: npm test


### PR DESCRIPTION
https://docs.npmjs.com/cli/ci.html

>This command is similar to npm-install, except it’s meant to be used in automated environments such as test platforms, continuous integration, and deployment – or any situation where you want to make sure you’re doing a clean install of your dependencies. It can be significantly faster than a regular npm install by skipping certain user-oriented features. It is also more strict than a regular install, which can help catch errors or inconsistencies caused by the incrementally-installed local environments of most npm users.